### PR TITLE
Corrections to "Installing on Unix-like Systems"

### DIFF
--- a/draft/unix.html
+++ b/draft/unix.html
@@ -22,8 +22,6 @@ sudo aptitude install couchdb
 
 <p>When this completes, you should have a copy of CouchDB running on your machine. Be sure to read through the Debian-specific system documentation that can be found under <code>/usr/share/couchdb</code>.
 
-<p>Starting with Ubuntu 9.10 (“Karmic”), CouchDB comes preinstalled with every desktop system.
-
 <h3 id="ubuntu">Ubuntu</h3>
 
 <p>You can install the CouchDB package by running:
@@ -33,6 +31,8 @@ sudo aptitude install couchdb
 </pre>
 
 <p>When this completes, you should have a copy of CouchDB running on your machine. Be sure to read through the Ubuntu-specific system documentation that can be found under <code>/usr/share/doc/couchdb</code>.
+
+<p>Starting with Ubuntu 9.10 (“Karmic”), CouchDB comes preinstalled with every desktop system.
 
 <h3 id="gentoo">Gentoo Linux</h3>
 

--- a/draft/unix.html
+++ b/draft/unix.html
@@ -20,7 +20,7 @@
 sudo aptitude install couchdb
 </pre>
 
-<p>When this completes, you should have a copy of CouchDB running on your machine. Be sure to read through the Debian-specific system documentation that can be found under <code>/usr/share/couchdb</code>.
+<p>When this completes, you should have a copy of CouchDB running on your machine. Be sure to read through the Debian-specific system documentation that can be found under <code>/usr/share/doc/couchdb</code>.
 
 <h3 id="ubuntu">Ubuntu</h3>
 


### PR DESCRIPTION
Please pull these two corrections:
- correct path to Debian-specific documentation about chouchdb is /usr/share/doc/couchdb (was without "doc")
- note about couchdb availability in Ubuntu belongs to part about Ubuntu (was in Debian)
