### PR TITLE
Typo in 1st Edition, mistaken reference in Draft

### DIFF
--- a/draft/views.html
+++ b/draft/views.html
@@ -111,7 +111,7 @@ function(doc) {
 
 <p>The view result is stored in a B-tree, just like the structure that is responsible for holding your documents. View B-trees are stored in their own file, so that for high-performance CouchDB usage, you can keep views on their own disk. The B-tree provides very fast lookups of rows by key, as well as efficient streaming of rows in a key range. In our example, a single view can answer all questions that involve time: “Give me all the blog posts from last week” or “last month” or “this year.” Pretty neat. Read more about how CouchDB’s B-trees work in <a href="btree.html">Appendix F, The Power of B-trees</a>.
 
-<p>When we query our view, we get back a list of all documents sorted by date. Each row also includes the post title so we can construct links to posts. Figure 1 is just a graphical representation of the view result. The actual result is JSON-encoded and contains a little more metadata:
+<p>When we query our view, we get back a list of all documents sorted by date. Each row also includes the post title so we can construct links to posts. Table 1 is just a graphical representation of the view result. The actual result is JSON-encoded and contains a little more metadata:
 
 <pre>
 {

--- a/editions/1/en/design.html
+++ b/editions/1/en/design.html
@@ -109,7 +109,7 @@ http://127.0.0.1:5984/mydb/_design/admin
 
 <pre>
 curl -X PUT http://127.0.0.1:5984/basic
-curl -X PUT http://127.0.0.1:5984/basic/_design/example -data-binarymydesign.json
+curl -X PUT http://127.0.0.1:5984/basic/_design/example --data-binary @mydesign.json
 </pre>
 
 <p>From the second request, you should see a response like:


### PR DESCRIPTION
1. Fixed a typo: "-data-binarymydesign.json" => "--data-binary @mydesign.json". After I made this change in order to submit the initial pull request, I noticed that the draft version has it correct here. I'm not sure whether the 1st edition online should contain errors like this, however. Your call! :)
2. I noticed that Table 1 is referred to as "Figure 1" in a following paragraph and thought this correction was needed, since the actual Figure 1 png is used and referred to later.
