### PR TITLE
Fix interfering of prev/next keyboard navigation 

### DIFF
--- a/script.js
+++ b/script.js
@@ -364,8 +364,8 @@ function track() {
 
 function access(evt){
     prevNext=document.getElementsByTagName("link");
-    if(evt.keyCode==37){location=prevNext[1].href}
-    if(evt.keyCode==39){location=prevNext[2].href}
+    if(evt.keyCode==37 && !evt.altKey){location=prevNext[1].href}
+    if(evt.keyCode==39 && !evt.altKey){location=prevNext[2].href}
 }
 
 document.onready = function() {


### PR DESCRIPTION
Only navigate via prev/next keyboard navigation if the alt key wasn’t pressed. This was really annoying as I navigate between tabs via Cmd+Alt+Left/Right and it always changed the CouchDB Guide page.
