### PR TITLE
Eventual Consistency: adding Git to the version control comparison with Subversion

### DIFF
--- a/draft/consistency.html
+++ b/draft/consistency.html
@@ -114,7 +114,7 @@
 
 </div>
 
-<p>Documents in CouchDB are versioned, much like they would be in a regular version control system such as Subversion. If you want to change a value in a document, you create an entire new version of that document and save it over the old one. After doing this, you end up with two versions of the same document, one old and one new.
+<p>Documents in CouchDB are versioned, much like they would be in a regular version control system such as Subversion or Git. If you want to change a value in a document, you create an entire new version of that document and save it over the old one. After doing this, you end up with two versions of the same document, one old and one new.
 
 <p>How does this offer an improvement over locks? Consider a set of requests wanting to access a document. The first request reads the document. While this is being processed, a second request changes the document. Since the second request includes a completely new version of the document, CouchDB can simply append it to the database without having to wait for the read request to finish.
 


### PR DESCRIPTION
Given that Git is so widespread, I think it makes sense to compare CouchDB's versioning to the much more modern Git as well as Subversion.
