### PR TITLE
Why CouchDB: replacing 'G1' with 'Android'

### DIFF
--- a/draft/why.html
+++ b/draft/why.html
@@ -148,7 +148,7 @@ Apache CouchDB has started. Time to relax.
 
 <p>CouchDB takes quite a few lessons learned from the Web, but there is one thing that could be improved about the Web: latency. Whenever you have to wait for an application to respond or a website to render, you almost always wait for a network connection that isn’t as fast as you want it at that point. Waiting a few seconds instead of milliseconds greatly affects user experience and thus user satisfaction.
 
-<p>What do you do when you are offline? This happens all the time—your DSL or cable provider has issues, or your iPhone, G1, or Blackberry has no bars, and no connectivity means no way to get to your data.
+<p>What do you do when you are offline? This happens all the time—your DSL or cable provider has issues, or your iPhone, Android, or Blackberry has no bars, and no connectivity means no way to get to your data.
 
 <p>CouchDB can solve this scenario as well, and this is where scaling is important again. This time it is scaling down. Imagine CouchDB installed on phones and other mobile devices that can synchronize data with centrally hosted CouchDBs when they are on a network. The synchronization is not bound by user interface constraints like subsecond response times. It is easier to tune for high bandwidth and higher latency than for low bandwidth and very low latency. Mobile applications can then use the local CouchDB to fetch data, and since no remote networking is required for that, latency is low by default.
 


### PR DESCRIPTION
G1 is, I think, a reference to one of the first Android phones on T-Mobile. At best, it's extremely dated, and often the reader will be left wondering what a G1 is.
