### PR TITLE
Disable arrow-based navigation when modifiers are used

### DIFF
--- a/script.js
+++ b/script.js
@@ -384,6 +384,7 @@ function track() {
 }
 
 function access(evt){
+    if (evt.shiftKey || evt.altKey || evt.ctrlKey || evt.metaKey) return;
     prevNext=document.getElementsByTagName("link");
     if(evt.keyCode==37){location=prevNext[1].href}
     if(evt.keyCode==39){location=prevNext[2].href}


### PR DESCRIPTION
On Mac Firefox (at least) the keyboard shortcut to switch next/previous tab is Cmd-Alt-{Left,Right}. The navigation script in the guide only sees that there's a Left/Right key being pressed and navigates on every tab switch. This leads to totally maddening behaviour whereby switching between the guide and another tab next to it (which is typical in development) causes the guide to navigate. Checking for modifiers fixes this.
