### PR TITLE
tour.html: remove false claim that engine "shuts off indexing" on view errors

### DIFF
--- a/draft/tour.html
+++ b/draft/tour.html
@@ -363,7 +363,7 @@ function(doc) {
 }
 </pre>
 
-<p>Here, we first check that the document has the fields we want to use. CouchDB recovers gracefully from a few isolated map function failures, but when a map function fails regularly (due to a missing required field or other JavaScript exception), CouchDB shuts off its indexing to prevent any further resource usage. For this reason, it’s important to check for the existence of any fields before you use them. In this case, our map function will skip the first “hello world” document we created without emitting any rows or encountering any errors. The result of this query should look like <a href="#figure/9">Figure 9, “The results of running a view after grouping by item type and price”</a>.
+<p>Here, we first check that the document has the fields we want to use, skipping the first “hello world” document we created. The result of this query should look like <a href="#figure/9">Figure 9, “The results of running a view after grouping by item type and price”</a>.
 
 <div class="figure" id="figure/9">
 


### PR DESCRIPTION
I couldn't find any mention of this anywhere else (googled for "couchdb view disable", "couchdb index disabled on error", etc.), and Robert Newson says on the [Clarifications on CouchDB "index disabling" behavior on view errors/exceptions](https://pony-poc.apache.org/thread.html/Z3bfw8o39wme617) mailing list thread:

> Interesting find. I don’t believe this was ever true, the view engine will continue to build in the face of exceptions being thrown for every single document it encounters.

→ Proposing to remove this claim. Note that I don't have any code/proof to back this removal, maybe there _is_ some feature that would deserve mention here, but the internets don't seem to know what it is. As to why this paragraph is here if indeed no such feature exists, I don't know: maybe the initial author stumbled upon a bug? Maybe s/he misunderstood CouchDB's behavior?
